### PR TITLE
Fill in missing year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) [year], Bryan Clark <clarkbw@github.com>
+Copyright (c) 2017, Bryan Clark <clarkbw@github.com>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Year was missing (this), author escaped (#1).

(Fixes in scaffolding at https://github.com/probot/template/pull/27 and https://github.com/probot/create-probot-app/pull/14)